### PR TITLE
fix: Balance dance jumpy width

### DIFF
--- a/docs/sdk/super-tokens/balance-dance.mdx
+++ b/docs/sdk/super-tokens/balance-dance.mdx
@@ -248,7 +248,7 @@ If you run into this issue, you can try to set a fixed width to the component li
 ```
 This should fix the jumpy behaviour and make the component flow smoothly like the example below:
 <div style={{ display: "flex", fontSize: "1.2rem", fontWeight: "bold", justifyContent: "center" }}>
-  <div style={{ width: "160px", margin: "auto" }}>
+  <div style={{ width: "180px", margin: "auto" }}>
    ✅ <FlowingBalance startingBalance={BigInt("1000000000000000000")} startingBalanceDate={new Date('2024-01-01T00:00:00.000Z')} flowRate={BigInt("1000000000000000")} />
   </div>
 </div>


### PR DESCRIPTION
The current docs in the original repo has a fixed width too small that is causing a jumpier behaviour than the bad example
https://docs.superfluid.org/docs/sdk/super-tokens/balance-dance

This can be fixed by increasing the width of the container. The new size should be able to fit a number like `999999.999999` which would theoretically take around 30 years to hit. Docs would probably be updated by then 